### PR TITLE
Return empty message response on an empty body

### DIFF
--- a/injectionapi/sendvalidator.go
+++ b/injectionapi/sendvalidator.go
@@ -40,7 +40,7 @@ func (sendValidator) ValidateBasicMessage(basicMessage message.BasicMessage) (re
 		response.Result = SendResultEMAILADDRESSVALIDATIONINVALIDFROM
 
 	} else if !isValidBasicMessage(basicMessage) {
-		response.Result = SendResultRECIPIENTVALIDATIONINVALIDREPLYTO
+		response.Result = SendResultEMPTYMESSAGE
 
 	} else if !isValidBasicMessageCustomHeaders(basicMessage) {
 		response.Result = SendResultMESSAGEVALIDATIONINVALIDCUSTOMHEADERS


### PR DESCRIPTION
When attempting to send a message with an empty body, the returned response is `SendResultRECIPIENTVALIDATIONINVALIDREPLYTO` which is confusing given that the ReplyTo field is optional. This PR changes this so `SendResultEMPTYMESSAGE` in such case.